### PR TITLE
Added RequiresOptIn compiler argument

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
+        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
     }
     buildFeatures {
         compose true


### PR DESCRIPTION
Resolves the warning on `@OptIn(ExperimentalComposeUiApi::class)`